### PR TITLE
Calling double Pause should be a no-op.

### DIFF
--- a/XamlAnimatedGif/TimingManager.cs
+++ b/XamlAnimatedGif/TimingManager.cs
@@ -102,6 +102,11 @@ namespace XamlAnimatedGif
         public void Pause()
         {
             IsPaused = true;
+            if (_pauseCompletionSource != null) 
+            {
+                var tcs = _pauseCompletionSource;
+                tcs?.TrySetResult(0); 
+            }
             _pauseCompletionSource = new TaskCompletionSource<int>();
         }
 


### PR DESCRIPTION
By checking for and completing the TaskCompletionSource before creating a new one, we don't double stop the async thread if someone makes an error and calls pause twice.

This fixes Issue: #170  https://github.com/XamlAnimatedGif/XamlAnimatedGif/issues/170 

From the discussion section of the bug; 

I'll do a pull request on the first of the expected behavior; _animator.Play(); resumes animation even if you have paused it twice.

Sure, someone can implement a Boolean, or check _animator.IsPaused first to know if the animation is already paused, however, the documentation isn't clear enough to know that you must do that and calling a double Pause would break the threading model.

When it doesn't work, it's really tough for someone figure out why calling resume isn't working. I just assumed that it was buggy for several months and tried to use it as little as possible.

There isn't any message or other notification that you broke it.

Furthermore, in other frameworks, if you call pause twice or resume twice, the result is it pauses or resumes respectively. The double action is a no-op.